### PR TITLE
get_last_trade is deprecated

### DIFF
--- a/HFT-ish_2.py
+++ b/HFT-ish_2.py
@@ -78,7 +78,7 @@ def awaitMarketOpen():
 #%%
 
 def checkprice(tick):
-    return alpaca.get_last_trade(tick).price
+    return alpaca.get_latest_trade(tick).price
 
 def daytrade_sell_check(tick):
     


### PR DESCRIPTION
in recent versions of alpaca_trade_api we use `get_latest_trade` instead of `get_last_trade`